### PR TITLE
Implementing automatic pip mode

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/src/main/kotlin/eu/wroblewscy/marcin/floating/floating/FloatingPlugin.kt
+++ b/android/src/main/kotlin/eu/wroblewscy/marcin/floating/floating/FloatingPlugin.kt
@@ -36,7 +36,7 @@ class FloatingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     context = flutterPluginBinding.applicationContext
   }
 
-  @RequiresApi(Build.VERSION_CODES.N)
+  @RequiresApi(Build.VERSION_CODES.O)
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
     if (call.method == "enablePip") {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -63,6 +63,37 @@ class FloatingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
       } else {
         result.success(activity.enterPictureInPictureMode())
       }
+    } else if (call.method == "toggleAutoPip") {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        var autoEnter = call.argument<Boolean>("autoEnter");
+
+        val builder = PictureInPictureParams.Builder()
+            .setAutoEnterEnabled(autoEnter!!)
+            .setAspectRatio(
+              Rational(
+                call.argument("numerator") ?: 16,
+                call.argument("denominator") ?: 9
+              )
+            )
+        val sourceRectHintLTRB = call.argument<List<Int>>("sourceRectHintLTRB")
+        if (sourceRectHintLTRB?.size == 4) {
+          val bounds = Rect(
+            sourceRectHintLTRB[0],
+            sourceRectHintLTRB[1],
+            sourceRectHintLTRB[2],
+            sourceRectHintLTRB[3]
+          )
+          builder.setSourceRectHint(bounds)
+        }
+
+        activity.setPictureInPictureParams(builder.build())
+
+        result.success(true)
+      } else {
+        result.success(false)
+      }
+    } else if (call.method == "autoPipAvailable") {
+      result.success(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
     } else if (call.method == "pipAvailable") {
       result.success(
           activity.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)

--- a/lib/src/floating.dart
+++ b/lib/src/floating.dart
@@ -29,7 +29,8 @@ class Floating {
 
   /// Checks if the device supports entering PiP mode automatically
   Future<bool> get isAutoPipAvailable async {
-    final bool? supportsAutoPip = await _channel.invokeMethod('autoPipAvailable');
+    final bool? supportsAutoPip =
+        await _channel.invokeMethod('autoPipAvailable');
     return supportsAutoPip ?? false;
   }
 
@@ -115,11 +116,10 @@ class Floating {
   /// Note that calling this function will NOT enable PiP mode.
   /// Instead, it ensures that PiP mode will afterwards be enabled
   /// automatically whenever the app goes into the background
-  Future<bool> toggleAutoPip({
-    Rational aspectRatio = const Rational.landscape(),
-    Rectangle<int>? sourceRectHint,
-    bool? autoEnter
-  }) async {
+  Future<bool> toggleAutoPip(
+      {Rational aspectRatio = const Rational.landscape(),
+      Rectangle<int>? sourceRectHint,
+      bool? autoEnter}) async {
     if (!aspectRatio.fitsInAndroidRequirements) {
       throw RationalNotMatchingAndroidRequirementsException(aspectRatio);
     }

--- a/lib/src/floating.dart
+++ b/lib/src/floating.dart
@@ -27,6 +27,16 @@ class Floating {
     return supportsPip ?? false;
   }
 
+  /// Confirms or denies automatic PiP availability.
+  ///
+  /// Automatic PiP may be unavailable because of system settings managed
+  /// by admin or device manufacturer. Also, the device may
+  /// have Android version that was released without this feature.
+  Future<bool> get isAutoPipAvailable async {
+    final bool? supportsAutoPip = await _channel.invokeMethod('autoPipAvailable');
+    return supportsAutoPip ?? false;
+  }
+
   /// Checks current app PiP status.
   ///
   /// When `false` the app can call [enable] method.
@@ -65,13 +75,13 @@ class Floating {
   ///
   /// PiP may be unavailable because of system settings managed
   /// by admin or device manufacturer. Also, the device may
-  /// have Android version that was released without this feature.
+  /// have an Android version that was released without this feature.
   ///
   /// Provide [aspectRatio] to override default 16/9 aspect ratio.
   /// [aspectRatio] must fit into Android-supported values:
   /// min: 1/2.39, max: 2.39/1, otherwise [RationalNotMatchingAndroidRequirementsException]
   /// will be thrown.
-  /// Note: this will not make any effect on Android SDK older than 26.
+  /// Note: this will not have any effect on Android SDK older than 26.
   Future<PiPStatus> enable({
     Rational aspectRatio = const Rational.landscape(),
     Rectangle<int>? sourceRectHint,
@@ -96,6 +106,47 @@ class Floating {
     return enabledSuccessfully ?? false
         ? PiPStatus.enabled
         : PiPStatus.unavailable;
+  }
+
+  /// Emabled or diables automatic PiP mode.
+  ///
+  /// When enabled, PiP mode automatically starts when the app is
+  /// put into the background and can be ended by the user via system UI.
+  ///
+  /// Automatic PiP may be unavailable because of system settings managed
+  /// by admin or device manufacturer. Also, the device may
+  /// have an Android version that was released without this feature.
+  ///
+  /// Provide [aspectRatio] to override default 16/9 aspect ratio.
+  /// [aspectRatio] must fit into Android-supported values:
+  /// min: 1/2.39, max: 2.39/1, otherwise [RationalNotMatchingAndroidRequirementsException]
+  /// will be thrown.
+  /// Note: this will not have any effect on Android SDK older than 26.
+  Future<bool> toggleAutoPip({
+    Rational aspectRatio = const Rational.landscape(),
+    Rectangle<int>? sourceRectHint,
+    bool? autoEnter
+  }) async {
+    if (!aspectRatio.fitsInAndroidRequirements) {
+      throw RationalNotMatchingAndroidRequirementsException(aspectRatio);
+    }
+
+    final bool? toggledSuccessfully = await _channel.invokeMethod(
+      'toggleAutoPip',
+      {
+        ...aspectRatio.toMap(),
+        if (sourceRectHint != null)
+          'sourceRectHintLTRB': [
+            sourceRectHint.left,
+            sourceRectHint.top,
+            sourceRectHint.right,
+            sourceRectHint.bottom,
+          ],
+        'autoEnter': autoEnter,
+      },
+    );
+
+    return toggledSuccessfully ?? false;
   }
 
   // Disposes internal components used to update the [isInPipMode$] stream.

--- a/lib/src/floating.dart
+++ b/lib/src/floating.dart
@@ -27,11 +27,7 @@ class Floating {
     return supportsPip ?? false;
   }
 
-  /// Confirms or denies automatic PiP availability.
-  ///
-  /// Automatic PiP may be unavailable because of system settings managed
-  /// by admin or device manufacturer. Also, the device may
-  /// have Android version that was released without this feature.
+  /// Checks if the device supports entering PiP mode automatically
   Future<bool> get isAutoPipAvailable async {
     final bool? supportsAutoPip = await _channel.invokeMethod('autoPipAvailable');
     return supportsAutoPip ?? false;
@@ -108,20 +104,17 @@ class Floating {
         : PiPStatus.unavailable;
   }
 
-  /// Emabled or diables automatic PiP mode.
+  /// Toggles between entering PiP mode automatically or not
   ///
-  /// When enabled, PiP mode automatically starts when the app is
-  /// put into the background and can be ended by the user via system UI.
+  /// The parameters [aspectRatio] and [sourceRectHint] are
+  /// identical to the onces used in the function [enable]
+  /// The parameter [autoEnter] specifies whether to enter PiP
+  /// mode automatically with the given parameters (true) or
+  /// not (false)
   ///
-  /// Automatic PiP may be unavailable because of system settings managed
-  /// by admin or device manufacturer. Also, the device may
-  /// have an Android version that was released without this feature.
-  ///
-  /// Provide [aspectRatio] to override default 16/9 aspect ratio.
-  /// [aspectRatio] must fit into Android-supported values:
-  /// min: 1/2.39, max: 2.39/1, otherwise [RationalNotMatchingAndroidRequirementsException]
-  /// will be thrown.
-  /// Note: this will not have any effect on Android SDK older than 26.
+  /// Note that calling this function will NOT enable PiP mode.
+  /// Instead, it ensures that PiP mode will afterwards be enabled
+  /// automatically whenever the app goes into the background
   Future<bool> toggleAutoPip({
     Rational aspectRatio = const Rational.landscape(),
     Rectangle<int>? sourceRectHint,


### PR DESCRIPTION
Implementation of two new functions `Floating.toggleAutoPip` and `Floating.isAutoPipAvailable`, the first of which explicitly calls `setAutoEnterEnabled` on the Android side. This way, the user can toggle automatic PiP mode on with `Floating.toggleAutoPip(autoEnter: true)` or off with `Floating.toggleAutoPip(autoEnter: false)`, depending on the current state of the app. Just like `Floating.enable`, `Floating.toggleAutoPip` takes `aspectRatio`and `sourceRectHint`as additional parameters.

However, this additional functionality somewhat breaks the implementation of  `PiPStatus`, since PiP can be entered automatically, without calling `Floating.enable`. Maybe, one should also implement `PipStatus.automatic`?