### PR TITLE
removed obsolete import

### DIFF
--- a/android/src/main/kotlin/eu/wroblewscy/marcin/floating/floating/FloatingPlugin.kt
+++ b/android/src/main/kotlin/eu/wroblewscy/marcin/floating/floating/FloatingPlugin.kt
@@ -16,7 +16,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import java.util.*
 import kotlin.concurrent.fixedRateTimer
 


### PR DESCRIPTION
removed an obsolete import which prevented building with Flutter v3.29.0