### PR TITLE
Fix to avoid lastEnableArguments to be set to null due to cancelOnLeavePiP call

### DIFF
--- a/lib/src/floating.dart
+++ b/lib/src/floating.dart
@@ -137,12 +137,12 @@ class Floating {
     // Cancel any previous settings in case it would interfere with the
     // current ones, e.g. current one is ImmediatePiP but OnLeavePiP
     // was called before.
-    await cancelOnLeavePiP();
-
-    // Moved this here as setting it on the first line does not make sense since
-    // it will be overridden by the cancelOnLeavePiP call.
-    lastEnableArguments = arguments;
-
+    try {
+      await cancelOnLeavePiP();
+    } finally {
+      // Ensure lastEnableArguments is always set, even if cancelOnLeavePiP throws.
+      lastEnableArguments = arguments;
+    }
     final bool? enabledSuccessfully = await _channel.invokeMethod(
       'enablePip',
       {

--- a/lib/src/floating.dart
+++ b/lib/src/floating.dart
@@ -117,7 +117,6 @@ class Floating {
   ///
   /// Note: this will not make any effect on Android SDK older than 26.
   Future<PiPStatus> enable(EnableArguments arguments) async {
-    lastEnableArguments = arguments;
     final (aspectRatio, sourceRectHint, autoEnable) = switch (arguments) {
       ImmediatePiP(:final aspectRatio, :final sourceRectHint) => (
           aspectRatio,
@@ -139,6 +138,11 @@ class Floating {
     // current ones, e.g. current one is ImmediatePiP but OnLeavePiP
     // was called before.
     await cancelOnLeavePiP();
+
+    // Moved this here as setting it on the first line does not make sense since
+    // it will be overridden by the cancelOnLeavePiP call.
+    lastEnableArguments = arguments;
+
     final bool? enabledSuccessfully = await _channel.invokeMethod(
       'enablePip',
       {


### PR DESCRIPTION
## What 

Fix to avoid lastEnableArguments to be set to null due to cancelOnLeavePiP call

## Why 

This will avoid the case where pip status is always disabled and not automatic when it should be automatic post pip is enabled but not visible. (with respect to on LeavePIP)